### PR TITLE
feat: Create legal fund donation page

### DIFF
--- a/donate-legal.html
+++ b/donate-legal.html
@@ -1,0 +1,20 @@
+<h1>Fund Our Foundation</h1>
+
+<h2>Help Us Achieve 501(c)(3) Status</h2>
+<p>
+  Achieving 501(c)(3) non-profit status is the single most important step to ensure the long-term success and legitimacy of GrinBound. 
+  This official designation makes all future donations tax-deductible for our supporters and opens up opportunities for grants and corporate partnerships.
+</p>
+<p>
+  The funds raised on this page are dedicated exclusively to paying for the required 501(c)(3) application fees and the associated legal costs for professional review.
+</p>
+<p>
+  <strong>Please note:</strong> As we are not yet a 501(c)(3), your contribution on this page is a direct gift to the cause and is not tax-deductible at this time.
+</p>
+
+<h3>Donate Any Amount</h3>
+<form>
+  <label for="donation-amount">Enter Amount:</label><br>
+  <input type="text" id="donation-amount" name="donation-amount" placeholder="$50.00"><br><br>
+  <input type="submit" value="Contribute to Legal Fund">
+</form>


### PR DESCRIPTION
      This PR adds a new, dedicated page (donate-legal.html) for raising
      funds specifically for 501(c)(3) application and legal fees. This
      separates our fundraising goals for better clarity.